### PR TITLE
Bump unzip to patch fstream vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "iconv-lite": "~0.2.11",
     "lazy": "~1.0.11",
     "rimraf": "~2.0.2",
-    "unzip": "~0.0.4"
+    "unzip": "^0.1.11"
   },
   "config": {
     "update": true


### PR DESCRIPTION
The version of `unzip` currently in use relies on a vulnerable version of `fstream` - this PR simply patches the vulnerability by updating `unzip`.

Details on `fstream` vulnerability (CVSS 7.3 - High Severity) are here:
https://app.snyk.io/vuln/SNYK-JS-FSTREAM-174725